### PR TITLE
Update Amazon IVS Broadcast SDK to 1.2.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ platform :ios, '14.0'
 workspace 'Broadcasting'
 
 def amazonIVS
-    pod 'AmazonIVSBroadcast', '~> 1.1.0'
+    pod 'AmazonIVSBroadcast', '~> 1.2.0'
 end
 
 target 'Broadcasting' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSBroadcast (1.1.0)
+  - AmazonIVSBroadcast (1.2.0)
 
 DEPENDENCIES:
-  - AmazonIVSBroadcast (~> 1.1.0)
+  - AmazonIVSBroadcast (~> 1.2.0)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - AmazonIVSBroadcast
 
 SPEC CHECKSUMS:
-  AmazonIVSBroadcast: 22ac24e1b028807ee3b2daa24d0e04fbece69b31
+  AmazonIVSBroadcast: b52aa30ceb6e4ca35a51ad93b41cfd9700d378bb
 
-PODFILE CHECKSUM: 994de42d05eddca88c7d31c6dfe8712d8d0e0535
+PODFILE CHECKSUM: f5d1ec8e9d52a9acec830a0c82d3492f3cfa082f
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2


### PR DESCRIPTION
Update Amazon IVS Broadcast SDK to 1.2.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
