### PR TITLE
Update Amazon IVS Broadcast SDK to 1.3.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ platform :ios, '14.0'
 workspace 'Broadcasting'
 
 def amazonIVS
-    pod 'AmazonIVSBroadcast', '~> 1.2.0'
+    pod 'AmazonIVSBroadcast', '~> 1.3.0'
 end
 
 target 'Broadcasting' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSBroadcast (1.2.0)
+  - AmazonIVSBroadcast (1.3.0)
 
 DEPENDENCIES:
-  - AmazonIVSBroadcast (~> 1.2.0)
+  - AmazonIVSBroadcast (~> 1.3.0)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - AmazonIVSBroadcast
 
 SPEC CHECKSUMS:
-  AmazonIVSBroadcast: b52aa30ceb6e4ca35a51ad93b41cfd9700d378bb
+  AmazonIVSBroadcast: c08e6e48e14fa2b8a77a171161e3f59ee6a2c714
 
-PODFILE CHECKSUM: f5d1ec8e9d52a9acec830a0c82d3492f3cfa082f
+PODFILE CHECKSUM: 6577c82e59be1d3b3e20f22322cd3733a93bd2df
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
Update Amazon IVS Broadcast SDK to 1.3.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
