### PR TITLE
Update Amazon IVS Broadcast SDK to 1.5.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ platform :ios, '14.0'
 workspace 'Broadcasting'
 
 def amazonIVS
-    pod 'AmazonIVSBroadcast', '~> 1.5.0'
+    pod 'AmazonIVSBroadcast', '~> 1.5.2'
 end
 
 target 'Broadcasting' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSBroadcast (1.5.0)
+  - AmazonIVSBroadcast (1.5.2)
 
 DEPENDENCIES:
-  - AmazonIVSBroadcast (~> 1.5.0)
+  - AmazonIVSBroadcast (~> 1.5.2)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - AmazonIVSBroadcast
 
 SPEC CHECKSUMS:
-  AmazonIVSBroadcast: b116e2a6f579e7500914fc8cd634a8c079b56c98
+  AmazonIVSBroadcast: 0f479a56ea7496eb59aec299559e6a486ea32330
 
-PODFILE CHECKSUM: 61f26cfbd2d8791ce857e62b04ecda33629eecc7
+PODFILE CHECKSUM: 5da0749d4c957ac448a935d97dd2990f1d61f809
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
Update Amazon IVS Broadcast SDK to 1.5.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
