### PR TITLE
Add Background Audio Entitlement for custom background image/video

### DIFF
--- a/Broadcasting/Info.plist
+++ b/Broadcasting/Info.plist
@@ -40,6 +40,10 @@
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
   - The broadcast demo does provide the custom background image/video source feature but does not add the background audio entitlement in the limitation sections in the docs. Since customers are currently having problems with phonecalls etc. Good to add this entitlement in the demo.

    https://docs.aws.amazon.com/ivs/latest/userguide/broadcast-ios.html#broadcast-ios-background-video under limitations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
