### PR TITLE
Update Amazon IVS Broadcast SDK to 1.11.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ platform :ios, '14.0'
 workspace 'Broadcasting'
 
 def amazonIVS
-    pod 'AmazonIVSBroadcast', '~> 1.10.0'
+    pod 'AmazonIVSBroadcast', '~> 1.11.0'
 end
 
 target 'Broadcasting' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,18 +1,18 @@
 PODS:
-  - AmazonIVSBroadcast (1.10.0):
-    - AmazonIVSBroadcast/Core (= 1.10.0)
-  - AmazonIVSBroadcast/Core (1.10.0)
+  - AmazonIVSBroadcast (1.11.0):
+    - AmazonIVSBroadcast/Core (= 1.11.0)
+  - AmazonIVSBroadcast/Core (1.11.0)
 
 DEPENDENCIES:
-  - AmazonIVSBroadcast (~> 1.10.0)
+  - AmazonIVSBroadcast (~> 1.11.0)
 
 SPEC REPOS:
   https://github.com/CocoaPods/Specs.git:
     - AmazonIVSBroadcast
 
 SPEC CHECKSUMS:
-  AmazonIVSBroadcast: f9f1de5c3f8470404b5489cee50bbd6e9dc19ee1
+  AmazonIVSBroadcast: d20aaeba4913678b703bcac67992ae3dd34ba08e
 
-PODFILE CHECKSUM: d2c8048d3496da19d444b90adfb406d2554614db
+PODFILE CHECKSUM: 4e49dd6bc8afa4bbd0190ff9470abf24f3358f7b
 
 COCOAPODS: 1.12.0


### PR DESCRIPTION
Update Amazon IVS Broadcast SDK to 1.11.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
